### PR TITLE
feat: use deploy key for generating partials

### DIFF
--- a/.github/workflows/update-vcluster-docs.yaml
+++ b/.github/workflows/update-vcluster-docs.yaml
@@ -41,6 +41,7 @@ jobs:
         with:
           fetch-tags: 'true'
           ref: 'refs/tags/${{ steps.release.outputs.release_tag }}'
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
This is required to bypass the branch protection rules. We are using deploy key for the bot, as it's not possible to add GitHub actions to the bypass list of the branch protection rulesets.

Closes OPS-27