### PR TITLE
fix(ci): prevent refspec error during tag fetch in checkout

### DIFF
--- a/.github/workflows/update-vcluster-docs.yaml
+++ b/.github/workflows/update-vcluster-docs.yaml
@@ -42,6 +42,7 @@ jobs:
           fetch-tags: 'true'
           ref: 'refs/tags/${{ steps.release.outputs.release_tag }}'
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          fetch-depth: 0
 
       - name: Configure git
         run: |


### PR DESCRIPTION
Closes OPS-130

The workflow failed during actions/checkout with an [invalid refspec error](https://github.com/loft-sh/vcluster-config/actions/runs/14605466459/job/40973423005). This occurred because fetching all tags (Workspace-tags: true) conflicts with the default shallow clone (depth=1).

Fetching the full repository history should ensure tags can be resolved and fetched correctly.