### PR TITLE
fix(ci): use correct branch name to generate docs pr

### DIFF
--- a/.github/workflows/update-vcluster-docs.yaml
+++ b/.github/workflows/update-vcluster-docs.yaml
@@ -89,7 +89,7 @@ jobs:
           # commit changes
           git commit -m "chore: generate vCluster Platform partials for vCluster ${{ env.VERSION_TAG }}"
           git push -u origin -f ${branch_name}
-          gh pr create --fill
+          gh pr create --fill --head ${branch_name} 
           echo "Create PR in vcluster-docs"
 
       - name: Generate vCluster partials
@@ -123,5 +123,5 @@ jobs:
           # commit changes
           git commit -m "chore: generate vCluster partials for vCluster ${versionTag}"
           git push -u origin -f ${branch_name}
-          gh pr create --fill
+          gh pr create --fill --head ${branch_name} 
           echo "Create PR in vcluster-docs"


### PR DESCRIPTION
Closes OPS-133

Fix gh pr create "aborted" error in Update partials CI. Added `--head ${branch_name}` to explicitly specify the source branch after push, avoiding timing issues.

Error fro reference:

```bash
Run versionTag=${VERSION_TAG#"vcluster-v"}
parsed vCluster tag: 0.24
Switched to a new branch 'generate-partials-for-vcluster-v0.24'
[generate-partials-for-vcluster-v0.24 bdfd59b6] chore: generate vCluster partials for vCluster 0.24
 2 files changed, 4506 insertions(+)
 create mode 100644 configsrc/vcluster/0.24/default_values.yaml
 create mode 100644 configsrc/vcluster/0.24/vcluster.schema.json
remote: 
remote: Create a pull request for 'generate-partials-for-vcluster-v0.24' on GitHub by visiting:        
remote:      https://github.com/loft-sh/vcluster-docs/pull/new/generate-partials-for-vcluster-v0.24        
remote: 
To https://github.com/loft-sh/vcluster-docs.git
 * [new branch]        generate-partials-for-vcluster-v0.24 -> generate-partials-for-vcluster-v0.24
branch 'generate-partials-for-vcluster-v0.24' set up to track 'origin/generate-partials-for-vcluster-v0.24'.
aborted: you must first push the current branch to a remote, or use the --head flag
Error: Process completed with exit code 1.
```